### PR TITLE
Flags w env var fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+export TARGET_NAME="test"
+export TARGET_URL="https://www.google.com"
+export SCHEDULE="* * * * * *"

--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/briangreenhill/blackbox/web"
 )
 
+const defaultSchedule = "* * * * * *"
+
 var (
 	url      string
 	schedule string
@@ -29,8 +31,12 @@ func init() {
 
 func main() {
 	flag.Parse()
-	if schedule == "" || url == "" {
-		log.Fatal("schedule and url are required fields")
+	if url == "" {
+		log.Fatal("url is required")
+	}
+
+	if schedule == "" {
+		schedule = defaultSchedule
 	}
 
 	checker := &web.Checker{

--- a/main.go
+++ b/main.go
@@ -29,8 +29,8 @@ func init() {
 
 func main() {
 	flag.Parse()
-	if url == "" {
-		log.Fatal("url is required")
+	if schedule == "" || url == "" {
+		log.Fatal("schedule and url are required fields")
 	}
 
 	checker := &web.Checker{
@@ -54,6 +54,5 @@ func main() {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	s := <-signals
-	log.Printf("got %s signal, shutting down", s.String())
-	os.Exit(0)
+	log.Fatalf("got %s signal, shutting down", s.String())
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/briangreenhill/blackbox/cmd"
 	"github.com/briangreenhill/blackbox/cron"
@@ -17,16 +16,15 @@ import (
 )
 
 var (
-	defaultSchedule = "* * * * * *"
-	url             string
-	schedule        string
-	name            string
+	url      string
+	schedule string
+	name     string
 )
 
 func init() {
-	flag.StringVar(&name, "name", "check_"+time.Now().Format("2006-01-02_15:04"), "The name of the check")
-	flag.StringVar(&url, "url", "", "The URL to check")
-	flag.StringVar(&schedule, "schedule", defaultSchedule, "The schedule in six star format")
+	flag.StringVar(&name, "name", os.Getenv("TARGET_NAME"), "The name of the check")
+	flag.StringVar(&url, "url", os.Getenv("TARGET_URL"), "The URL to check")
+	flag.StringVar(&schedule, "schedule", os.Getenv("SCHEDULE"), "The schedule in six star format")
 }
 
 func main() {


### PR DESCRIPTION
fixes #4

## TODO

- [x] have environment variables stand in as defaults for the flags
- [x] fall back to default schedule if env var missing